### PR TITLE
Sped up initial creation of tailable cursor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,13 +96,14 @@ Oplog.prototype.tail = function tail(fn) {
       , options = {
           tailable: true,
           awaitdata: true,
+          oplogReplay: true,
           timeout: false,
           numberOfRetries: -1
         };
 
     coll
       .find({}, { ts: 1 })
-      .sort({ ts: -1 })
+      .sort({ $natural: -1 })
       .limit(1)
       .nextObject(function next(err, doc) {
         if (err) {


### PR DESCRIPTION
Using a `$natural` sort on the `local.oplog.rs` capped collection is a significantly faster query than sorting on the unindexed `ts` field.
Also, specifying the `oplogReplay` option allows us to act like a replica secondary, skipping forward through most of the oplog until our value of `ts` is found, i.e. not doing a full table scan to find the value of `ts`.

Before this change, I tried tailing from a replica set with an oplog size of 14 GB and the oplog tailer hung indefinitely! Giving it the benefit of the doubt, I left it doing the initial query, watching memory usage of my mongod going up a lot until I eventually had to kill the operation after about 25 minutes!!

When this change was introduced, the oplog-tailer started tailing almost immediately on restart - a drastic improvement!

I hope you will consider merging this change into an otherwise fantastic module.

Thanks,
Colm