### PR TITLE
Fix for error 'No more documents in tailed cursor' in log

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ Oplog.prototype.tail = function tail(fn) {
           awaitdata: true,
           oplogReplay: true,
           timeout: false,
-          numberOfRetries: -1
+          numberOfRetries: Number.MAX_VALUE
         };
 
     coll


### PR DESCRIPTION
See NODE-435 (https://jira.mongodb.org/browse/NODE-435)