### PR TITLE
numberOfRetries: -1 is no longer accepted

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ Oplog.prototype.tail = function tail(fn) {
           awaitdata: true,
           oplogReplay: true,
           timeout: false,
-          numberOfRetries: -1
+          numberOfRetries: Number.MAX_VALUE
         };
 
     coll


### PR DESCRIPTION
As said in https://jira.mongodb.org/browse/NODE-435, the numberOfRetries: -1 is no longer accepted and must be now fixed to Number.MAX_VALUE.