### PR TITLE
Updated mongodb dependency to 2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "2.2.x",
     "eventemitter3": "^1.1.1",
     "mongo-oplog-cursor": "^0.2.0",
-    "mongodb": "~2.0.x",
+    "mongodb": "~2.1",
     "thunky": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There are new 2.1.x versions of the mongodb driver, but this project required 2.0.x.

I've run the mongo-oplog tests with the new dependency and everything seems fine.

The "should start re-tailing on timeout" test fails when run together with other tests, but passes when run separately. However, it also did that with the 2.0 driver, so the problem wasn't introduced with this dependency change.